### PR TITLE
Removed empty foo method

### DIFF
--- a/lib/attr_encryptor.rb
+++ b/lib/attr_encryptor.rb
@@ -293,9 +293,6 @@ module AttrEncryptor
       self.class.encrypt(attribute, value, evaluated_attr_encrypted_options_for(attribute))
     end
     
-    def foo
-
-    end
     protected
 
       # Returns attr_encrypted options evaluated in the current object's scope for the attribute specified


### PR DESCRIPTION
This is not cool, because it defines a method called foo on Object. There's an open issue for this: https://github.com/danpal/attr_encryptor/issues/5
