### PR TITLE
Fix migration example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ them will be populated automatically
     create_table :google_apps_admins do |t|
       t.string :username
       t.string :encrypted_password
+      t.string :encrypted_password_salt
       t.string :encrypted_password_iv
       t.string :domain
       t.timestamps


### PR DESCRIPTION
README was missing the salt column that it suggested to use. This causes decryption to fail.
